### PR TITLE
Search distributions by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl extension PGXN::Site
 
 0.22.3
       - Updated the donor links, removing or replacing dead URLs.
+      - Changed the default search index from "Documentation" to "Distributions".
+        Few releases include documentation other than a README, which pgxn-api
+        indexes in the distributions index and not the documentation index. So
+        make distribution search the default to improve the default search
+        experience.
 
 0.22.2  2023-02-18T23:25:58Z
       - Replaced Twitter link with Mastodon and added a rel link to Mastodon

--- a/lib/PGXN/Site/Templates.pm
+++ b/lib/PGXN/Site/Templates.pm
@@ -1383,9 +1383,9 @@ template search_form => sub {
                 name is 'in';
                 my $in = $args->{in};
                 for my $spec (
+                    [ dists      => 'Distributions' ],
                     [ docs       => 'Documentation' ],
                     [ extensions => 'Extensions'    ],
-                    [ dists      => 'Distributions' ],
                     [ users      => 'Users'         ],
                     [ tags       => 'Tags'          ]
                 ) {

--- a/t/templates.t
+++ b/t/templates.t
@@ -479,9 +479,9 @@ sub test_search_form {
 
                 my $i = 0;
                 for my $spec (
+                    [ dists      => 'Distributions' ],
                     [ docs       => 'Documentation' ],
                     [ extensions => 'Extensions'    ],
-                    [ dists      => 'Distributions' ],
                     [ users      => 'Users'         ],
                     [ tags       => 'Tags'          ],
                 ) {


### PR DESCRIPTION
Instead of documentation, because few releases include documentation other than a README, which pgxn-api indexes in the distributions index and not the documentation index.

So make distribution search the default to improve the default search experience.