### PR TITLE
Parse and format Multimarkdown at release time

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -6,32 +6,6 @@ my $class = Module::Build->subclass(
     class => 'PGXN::Build',
     code => q{
         sub valid_licenses { { postgresql => 'PostgreSQL' } }
-        sub process_mmd_files {
-            require Text::MultiMarkdown;
-            my $self  = shift;
-            my $m     = Text::MultiMarkdown->new(
-                img_ids     => 0,
-                heading_ids => 0,
-            );
-            my $files = $self->_find_file_by_type('mmd', 'lib');
-
-            while (my ($file, $to) = each %$files) {
-                $to =~ s{[.]mmd$}{.html};
-                $to = File::Spec->catfile($self->blib, $to);
-                unless ($self->up_to_date( $file, $to )) {
-                    File::Path::mkpath(File::Basename::dirname($to), 0, oct(777));
-                    $self->log_verbose("Converting $file -> $to\n");
-                    open my $in,  '<:utf8', $file or die "Cannot open $file: $!\n";
-                    chmod 0666, $to;
-                    open my $out, '>:utf8', $to   or die "Cannot open $to: $!\n";
-                    local $/;
-                    print $out $m->markdown(<$in>);
-                    close $in;
-                    chmod 0444, $to;
-
-                }
-            }
-        }
         sub ACTION_tarball_name { print shift->dist_dir . ".tar.gz\n" }
         sub ACTION_latest_changes {
             my $self = shift;
@@ -60,10 +34,6 @@ my $build = $class->new(
     license            => 'postgresql',
     script_files       => 'bin',
     configure_requires => { 'Module::Build' => '0.4209' },
-    build_requires     => {
-        'Module::Build'       => '0.4209',
-        'Text::MultiMarkdown' => 0,
-    },
     requires => {
         'Carp'                         => 0,
         'Data::Dump'                   => '1.17',
@@ -121,5 +91,5 @@ my $build = $class->new(
     },
 );
 
-$build->add_build_element($_) for qw(css gif png jpg js mmd eps svg json ico);
+$build->add_build_element($_) for qw(css gif png jpg js html eps svg json ico);
 $build->create_build_script;

--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl extension PGXN::Site
 
 0.23.7
       - Removed duplicate CC license image and link on the /art page.
+      - Moved the generation of HTML from Multimarkdown files from build
+        time to release time, and switched from Text::Multimarkdown to
+        the `multimarkdown` CLI.
+      - Tweaked the CSS for definition lists to open up space a bit more
+        between terms and definitions.
 
 0.23.6 2024-02-20T20:56:52Z
       - Tweaked the indentation of list items in the documentation "Contents"

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -5,7 +5,7 @@
 \B\.svn\b
 \B\.git
 
-# Avoid Makemaker generated and utility files.
+# Avoid MakeMaker generated and utility files.
 \bMakefile$
 \bblib
 \bMakeMaker-\d
@@ -30,6 +30,7 @@
 ^Capfile
 ^www
 ^assets
+^bin/format_l10n_docs
 
 # Avoid Pod tests.
 t/pod.+

--- a/bin/format_l10n_docs
+++ b/bin/format_l10n_docs
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl -w
+
+# Find all .mm?d files in lib, run them through multimarkdown, and write
+# to .html.
+#
+# brew install multimarkdown
+
+use 5.10.0;
+use strict;
+use warnings;
+use utf8;
+use File::Find;
+use File::Basename qw(basename);
+
+find({
+    no_chdir => 1,
+    wanted => sub {
+        return unless /\.mm?d$/;
+        my $src = $File::Find::name;
+        my $dst = $src =~ s/\.mm?d$/.html/r;
+        my @cmd = ('multimarkdown', $src, '-o', $dst);
+        system(@cmd) == 0  or die "system @cmd failed: $?\n"
+    },
+}, 'lib');

--- a/lib/PGXN/Site/Locale/en/about.html
+++ b/lib/PGXN/Site/Locale/en/about.html
@@ -1,0 +1,71 @@
+<h1 id="aboutpgxn">About PGXN</h1>
+
+<p>PGXN, the PostgreSQL Extension network, is a central distribution system for
+open-source PostgreSQL extension libraries. It consists of four basic parts:</p>
+
+<dl>
+<dt><a href="https://manager.pgxn.org/">PGXN Manager</a></dt>
+<dd>An upload and distribution infrastructure for extension developers.</dd>
+
+<dt><a href="https://github.com/pgxn/pgxn-api/wiki/">PGXN API</a></dt>
+<dd>A centralized index and API of distribution metadata.</dd>
+
+<dt><a href="https://pgxn.org/">PGXN Search</a></dt>
+<dd>This site, for searching extensions and perusing their documentation.</dd>
+
+<dt><a href="https://pgxn.github.io/pgxnclient/">PGXN Client</a></dt>
+<dd>A command-line client for downloading, testing, and installing extensions.</dd>
+</dl>
+
+<p>The network currently consists of:</p>
+
+<ul>
+<li>[_1] Extensions</li>
+<li>[_2] Distributions</li>
+<li>[_3] Releases</li>
+<li>[_4] Users</li>
+<li>[_5] Tags</li>
+<li>[_6] Mirrors</li>
+</ul>
+
+<h3 id="why">Why?</h3>
+
+<p>One of the primary distinguishing features of <a href="https://www.postgresql.org/">PostgreSQL</a>—and perhaps the
+number one reason to use it instead of another DBMS—is its extensibility and the
+large number of database extensions already available: <a href="https://postgis.net/">PostGIS</a>, <a href="https://www.postgresql.org/docs/current/isn.html">ISN</a>,
+<a href="https://www.postgresql.org/docs/current/hstore.html">hstore</a>, <a href="https://pgtap.org/">pgTAP</a>, <a href="https://github.com/postgres-plr/plr">PL/R</a>, <a href="https://plproxy.github.io">PL/Proxy</a>, and more. Especially with the formal
+support for <a href="https://www.postgresql.org/docs/current/extend-extensions.html" title="PostgreSQL Documentation: “Packaging Related Objects into an Extension”">extensions</a>, PostgreSQL today is not merely a database, it’s an
+application development platform. However, many of these extensions are
+virtually unknown even among experienced users because they are hard to find.</p>
+
+<p>PGXN solves the “hard to find” issue by providing centralized listings and
+searchable documentation for PostgreSQL extensions. Here you can easily search
+through extensions, browse their documentation, and download and install those
+that fill your needs. The site is structured to maximize the ability to find
+appropriate extensions and their documentation through search engines. Our hope
+is that the high visibility of PostgreSQL’s extensibility and the array of
+available extensions will drive PostgreSQL adoption by new users and application
+developers, expanding our community and ensuring another 10 years of the
+PostgreSQL Project.</p>
+
+<h3 id="who’sresponsibleforthis">Who’s Responsible for This?</h3>
+
+<p>Thanks to our <a href="https://pgxn.org/donors/">terrific donors</a>, <a href="https://justatheory.com/" title="Just a Theory">I am</a>. I’m David Wheeler, inveterate Perl and
+PostgreSQL hacker. I love the <a href="https://www.postgresql.org/docs/current/static/extend.html" title="PostgreSQL Documentation: Extending SQL”">extensibility of PostgreSQL</a> and have long been a
+fan of <a href="https://www.cpan.org/">CPAN</a>, the Perl community’s distributed collection of Perl software and
+documentation. But PostgreSQL’s extensibility is not well-known, and it’s
+difficult to find the extensions that do exist. PGXN is my attempt to solve that
+problem.</p>
+
+<h3 id="wanttohelp">Want to Help?</h3>
+
+<p>The source code for all the parts of PGXN are on <a href="https://github.com/pgxn/" title="PGXN on GitHub">GitHub</a>. Please feel free to
+fork and send merge requests! And join the discussion in the <a href="https://groups.google.com/group/pgxn-users" title="PGXN Users Group">Google Group</a>.</p>
+
+<h3 id="colophon">Colophon</h3>
+
+<p>The pgxn.org design is based on <a href="https://fullahead.org/projects/lazydays/">LazyDays</a> by <a href="https://fullahead.org/">Fullahead</a>, set in
+<a href="https://docs.microsoft.com/en-us/typography/font-list/trebuchet-ms">Trebuchet MS</a>, and features icons by <a href="https://icons8.github.io/flat-color-icons/" title="Flat Color Icons by Icons8">Icons8</a>. Strongrrl designed the
+<a href="https://pgxn.org/art/">graphic identity</a>.</p>
+
+<p>This site eschews JavaScript, and uses no tracking or analytics services.</p>

--- a/lib/PGXN/Site/Locale/en/art.html
+++ b/lib/PGXN/Site/Locale/en/art.html
@@ -1,0 +1,48 @@
+<h1 id="pgxngraphicidentity">PGXN Graphic Identity</h1>
+
+<figure>
+<img src="https://licensebuttons.net/l/by/4.0/88x31.png" alt="Creative Commons License" />
+<figcaption>Creative Commons License</figcaption>
+</figure>
+
+<a rel="license" href="https://creativecommons.org/licenses/by/4.0/">
+<img alt="Creative Commons License" src="https://licensebuttons.net/l/by/4.0/88x31.png" />
+</a>
+<br />
+The <span xmlns:dct="https://purl.org/dc/terms/" href="https://purl.org/dc/dcmitype/StillImage" property="dct:title" rel="dct:type">PGXN Graphic Identity</span>
+by <a xmlns:cc="https://creativecommons.org/ns" href="https://justatheory.com/" property="cc:attributionName" rel="cc:attributionURL">David E. Wheeler</a>,
+including the type treatments of the word "PGXN" and the phrase "PostgreSQL
+Extension Network", as well as the gear logo, is licensed under a
+<a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+Based on a work at <a xmlns:dct="https://purl.org/dc/terms/" href="https://pgxn.org/art/" rel="dct:source">pgxn.org</a>.
+Design by Strongrrl.
+
+<h3 id="logotype">Logo Type</h3>
+
+<ul>
+<li>The text &#8220;PGXN&#8221; is composed in
+<a href="https://www.myfonts.com/collections/bank-gothic-font-bitstream">Bank Gothic BT</a></li>
+<li>The text &#8220;PostgreSQL Extension Network&#8221; is rendered in
+<a href="https://www.myfonts.com/collections/myriad-font-adobe">Myriad</a> 215 LT condensed</li>
+</ul>
+
+<h3 id="logoart">Logo Art</h3>
+
+<ul>
+<li>PGXN Logo Type:
+<a href="/ui/img/pgxn.eps">EPS</a> |
+<a href="/ui/img/pgxn.svg">SVG</a> |
+<a href="/ui/img/pgxn.png">PNG</a></li>
+<li>PGXN Logo White Gear:
+<a href="/ui/img/gear.eps">EPS</a> |
+<a href="/ui/img/gear.svg">SVG</a> |
+<a href="/ui/img/gear-512.png">PNG</a></li>
+<li>PGXN Logo White Gear on Blue:
+<a href="/ui/img/icon.eps">EPS</a> |
+<a href="/ui/img/icon.svg">SVG</a> |
+<a href="/ui/img/icon-512.png">PNG</a></li>
+<li>PGXN Logo Black Gear:
+<a href="/ui/img/gear-black.eps">EPS</a> |
+<a href="/ui/img/gear-black.svg">SVG</a> |
+<a href="/ui/img/gear-black-512.png">PNG</a></li>
+</ul>

--- a/lib/PGXN/Site/Locale/en/faq.html
+++ b/lib/PGXN/Site/Locale/en/faq.html
@@ -1,0 +1,179 @@
+<h1 id="frequentlyaskedquestions">Frequently Asked Questions</h1>
+
+<h2 id="releasingonpgxn">Releasing on PGXN</h2>
+
+<dl>
+<dt><span id="extension"></span></dt>
+<dt>WTF is an “extension”?</dt>
+<dd>An extension is a piece of software that adds functionality to PostgreSQL
+itself. Examples are data types (<a href="https://www.postgresql.org/docs/current/citext.html">citext</a>, <a href="https://www.postgresql.org/docs/current/hstore.html">hstore</a>), utilities (<a href="https://www.postgresql.org/docs/current/dblink.html">dblink</a>,
+<a href="https://pgxn.org/extension/pgtap">pgTAP</a>), and procedural languages (<a href="https://www.postgresql.org/docs/current/plperl.html">PL/Perl</a>, <a href="https://github.com/postgres-plr/plr">PL/R</a>), among others. See
+<a href="https://www.postgresql.org/docs/current/extend.html">Extending SQL</a> for details.</dd>
+
+<dt><span id="allowed"></span></dt>
+<dt>What’s allowed to be released on PGXN?</dt>
+<dd>Open-source PostgreSQL extension release packages. The <a href="https://manager.pgxn.org/howto">How To</a> documents
+the contents of such packages. Following the <a href="https://www.cpan.org/misc/ZCAN.html">CPAN example</a>, “no commercial
+software of any kind, not even share/guilt/donateware, will be allowed…any
+other policy would be open to nitpicking, or maybe even legal challenges.”</dd>
+
+<dt><span id="notallowed"></span></dt>
+<dt>What’s not allowed to be released on PGXN?</dt>
+<dd>Non-package files (that is, files that are not tarballs, bzip-balls, or zip
+archives), closed-source distributions, and distributions with no license.</dd>
+
+<dt><span id="whocanrelease"></span></dt>
+<dt>Who can release on PGXN?</dt>
+<dd>Any registered user.</dd>
+
+<dt><span id="whocanregister"></span></dt>
+<dt>Who can register for PGXN?</dt>
+<dd>Anyone who applies. Such registrations will be approved by volunteers, but
+we’re usually pretty quick to respond to requests.</dd>
+
+<dt><span id="howtoapply"></span></dt>
+<dt>So how do I apply?</dt>
+<dd>Head on over to <a href="https://manager.pgxn.org/">PGXN Manager</a> and hit the “<a href="https://manager.pgxn.org/account/register">Request Account</a>” link. Once
+you’ve signed up, unless you’re obviously a <a href="https://en.wikipedia.org/wiki/Troll_(slang)">troll</a>, your account will be
+quickly approved.</dd>
+
+<dt><span id="releaseapproval"></span></dt>
+<dt>Okay, I have an account and want to release an extension. Is there a release</dt>
+<dt>approval process?</dt>
+<dd>Short answer: No, because PGXN needs to <a href="https://en.wikipedia.org/wiki/KISS_principle">KISS</a>. Longer answer: No. Again
+following the <a href="https://www.cpan.org/misc/ZCAN.html">CPAN example</a>, PGXN “is and will stay an open and free forum,
+where the authors decide what they upload. Any further selection belongs to
+different fora.” This is because “the first goal of PGXN is to make it easy
+to submit code and redistribute it. Ease of use and quality control are not
+the central problems ~[it~] tries to solve.” (Original quotation lost to
+time and internet entropy.) Frankly, moderation of releases is a significant
+reason that other communities have failed to duplicate the success of CPAN.</dd>
+
+<dt><span id="howto"></span></dt>
+<dt>Great, so how do I create an extension distribution and release it?</dt>
+<dd>Basically, you upload an archive file with a <a href="https://pgxn.org/spec/">META.json</a> file describing the
+distribution. Have a look at the <a href="https://manager.pgxn.org/howto">How To</a> for all the details.</dd>
+
+<dt><span id="github"></span></dt>
+<dt>I read that, but it seems like an awful lot of work for something that should be</dt>
+<dt>automated. Is there any way I can automatically have my extension appear on PGXN</dt>
+<dt>when I make a release on GitHub?</dt>
+<dd><p>Yes! You can use the <a href="https://github.com/pgxn/docker-pgxn-tools">pgxn-tools</a> Docker image as part of your release
+workflows. It supports both testing an extension with multiple versions of
+Postgres, as well as releasing extensions on GitHub and PGXN. For details,
+check out these blog posts:</p>
+
+<ul>
+<li><a href="https://justatheory.com/2020/06/test-extensions-with-github-actions/">Test Postgres Extensions With GitHub Actions</a></li>
+<li><a href="https://justatheory.com/2020/10/release-postgres-extensions-with-github-actions/">Automate Postgres Extension Releases on GitHub and PGXN</a></li>
+</ul></dd>
+
+<dt><span id="maillist"></dt>
+<dt>Is there some place I can go to ask questions and get help from like-minded PGXN</dt>
+<dt>contributors?</dt>
+<dd>Yes, there is a <a href="https://groups.google.com/group/pgxn-users">Google Group</a> for this very purpose. Join us!</dd>
+
+<dt><span id="goodbadugly"></span></dt>
+<dt>How does PGXN make it easy to distinguish the garbage from the viable</dt>
+<dt>extensions?</dt>
+<dd>The first step is the PGXN search engine, accessible via the <a href="https://pgxn.org/">home page</a>,
+which will allow you to find extensions relevant to you and to read their
+documentation. This will “often ~[be~] enough to distinguish the good stuff
+from the crap,” as <a href="https://www.postgresql.org/message-id/603c8f071001061718t40e42609y59a26165bb72ff01@mail.gmail.com">Robert Haas says</a>. As more extensions are released on
+PGXN with competing features and functionality, the addition of ratings
+features and dedicated testing will also make it easier to evaluate
+competing options.</dd>
+</dl>
+
+<h2 id="pgxnclient">PGXN Client</h2>
+
+<dl>
+<dt><span id="commandlineclient"></span></dt>
+<dt>Is there a command-line client for installing extensions from PGXN?</dt>
+<dd><p>There is! Install it with this command:</p>
+
+<pre><code class="sh">sudo easy_install pgxnclient
+</code></pre>
+
+<p>If you use <a href="https://brew.sh">Homebrew</a>:</p>
+
+<pre><code class="sh">brew install pgxnclient
+</code></pre>
+
+<p>Then you can install PGXN extensions with a simple command:</p>
+
+<pre><code class="sh">pgxn install pair
+</code></pre>
+
+<p>Run <code>pgxn help</code> to get a list of supported commands; or check out the
+introductory <a href="https://blog.pgxn.org/post/5026314153/writing-a-client-for-pgxn">blog</a> <a href="https://blog.pgxn.org/post/5118152273/new-release-for-the-pgxn-client">posts</a>, the <a href="https://pgxn.github.io/pgxnclient/">complete documentation</a> or the <a href="https://github.com/pgxn/pgxnclient">source
+code</a>.</p></dd>
+
+<dt><span id="howclientworks"></span></dt>
+<dt>How does the command-line client work?</dt>
+<dd>It uses JSON-based API available on every PGXN mirror to find, download,
+build, and install extensions. It relies on <a href="https://www.postgresql.org/docs/current/extend-pgxs.html">PGXS</a> to do the heavy lifting
+to build extensions.</dd>
+
+<dt><span id="clientwindows"></span></dt>
+<dt>What about Windows?</dt>
+<dd>The PGXN client follows the lead of the PostgreSQL core on installing
+extensions. If support for installing extensions on Windows improves such
+that a compiler is no longer required, the PGXN client will be modified as
+appropriate to take advantage of it. This applies not specifically to
+Windows, but to the ability of the core installer (or any future
+community-supported installer) to work on <em>any</em> platform.</dd>
+
+<dt><span id="clientsecurity"></span></dt>
+<dt>What kind of security does PGXN have?</dt>
+<dd>Each release package has an accompanying SHA1 hash that the PGXN client
+verifies before installing an extension.</dd>
+</dl>
+
+<h2 id="contributingtopgxn">Contributing to PGXN</h2>
+
+<dl>
+<dt><span id="license"></span></dt>
+<dt>Under what license is PGXN’s source code distributed?</dt>
+<dd><a href="https://www.postgresql.org/about/licence/">The PostgreSQL License</a>. Note that the actual extensions themselves may be
+under any open source license, determined by their authors.</dd>
+
+<dt><span id="contribute"></span></dt>
+<dt>Can other people contribute to PGXN?</dt>
+<dd>Definitely! Contributions and help with refining the specification are very
+welcome. Major code contributions may be funded out of the PGXN fund based
+on circumstances. Any contributions must be submitted under The PostgreSQL
+License.</dd>
+
+<dt><span id="mirroring"></span></dt>
+<dt>What about mirroring? Can I create a PGXN mirror?</dt>
+<dd>Absolutely! See <a href="https://pgxn.org/mirroring/">mirroring</a> for the details.</dd>
+
+<dt><span id="owners"></span></dt>
+<dt>Who owns and runs PGXN?</dt>
+<dd>Currently, PGXN is hosted on a box owned by <a href="https://www.depesz.com">depesz</a>. Eventually it may run
+on community servers, as the PostgreSQL.org Web Team determines. Or it may
+end up on one or more servers to be contributed to the <a href="https://www.postgresql.org/about/policies/funds-group/">PostgreSQL Funds
+Group</a>. In any case, the PGXN master index and server will always be
+contributed to the PostgreSQL community.</dd>
+
+<dt><span id="source"></span></dt>
+<dt>Where is the PGXN source code hosted?</dt>
+<dd><a href="https://github.com/pgxn/">On GitHub</a>. Please feel free to fork and send pull requests!</dd>
+
+<dt><span id="language"></span></dt>
+<dt>What language is PGXN written in?</dt>
+<dd>Mostly Perl. The database used by <a href="https://manager.pgxn.org/">PGXN Manager</a> is written in SQL,
+PL/pgSQL, and PL/Perl — and even uses <a href="https://pgxn.org/extension/semver">semver</a>, a <a href="https://semver.org/">semantic version</a> data
+type written in C and distributed right here on PGXN!</dd>
+
+<dt><span id="api"></span></dt>
+<dt>Is there an API?</dt>
+<dd>Yes! The <a href="https://github.com/pgxn/pgxn-api/wiki/">PGXN API</a> provides centralized index and API of distribution
+metadata, as well as the search APIs used here.</dd>
+
+<dt><span id="logos"></span></dt>
+<dt>Is the PGXN logo available for use?</dt>
+<dd>Yes, see <a href="https://pgxn.org/art/">identity</a> for the license details and downloadable artwork.</dd>
+</dl>
+

--- a/lib/PGXN/Site/Locale/en/faq.mmd
+++ b/lib/PGXN/Site/Locale/en/faq.mmd
@@ -6,7 +6,6 @@ Releasing on PGXN
 
 <span id="extension"></span>
 WTF is an “extension”?
-
 :   An extension is a piece of software that adds functionality to PostgreSQL
     itself. Examples are data types ([citext], [hstore]), utilities ([dblink],
     [pgTAP]), and procedural languages ([PL/Perl], [PL/R]), among others. See
@@ -14,7 +13,6 @@ WTF is an “extension”?
 
 <span id="allowed"></span>
 What’s allowed to be released on PGXN?
-
 :   Open-source PostgreSQL extension release packages. The [How To] documents
     the contents of such packages. Following the [CPAN example], “no commercial
     software of any kind, not even share/guilt/donateware, will be allowed…any
@@ -22,24 +20,20 @@ What’s allowed to be released on PGXN?
 
 <span id="notallowed"></span>
 What’s not allowed to be released on PGXN?
-
 :   Non-package files (that is, files that are not tarballs, bzip-balls, or zip
     archives), closed-source distributions, and distributions with no license.
                    
 <span id="whocanrelease"></span>
 Who can release on PGXN?
-
 :   Any registered user.
 
 <span id="whocanregister"></span>
 Who can register for PGXN?
-
 :   Anyone who applies. Such registrations will be approved by volunteers, but
     we’re usually pretty quick to respond to requests.
                    
 <span id="howtoapply"></span>
 So how do I apply?
-
 :   Head on over to [PGXN Manager] and hit the “[Request Account]” link. Once
     you’ve signed up, unless you’re obviously a [troll], your account will be
     quickly approved.
@@ -47,7 +41,6 @@ So how do I apply?
 <span id="releaseapproval"></span>
 Okay, I have an account and want to release an extension. Is there a release
 approval process?
-
 :   Short answer: No, because PGXN needs to [KISS]. Longer answer: No. Again
     following the [CPAN example], PGXN “is and will stay an open and free forum,
     where the authors decide what they upload. Any further selection belongs to
@@ -59,7 +52,6 @@ approval process?
                    
 <span id="howto"></span>
 Great, so how do I create an extension distribution and release it?
-
 :   Basically, you upload an archive file with a [META.json] file describing the
     distribution. Have a look at the [How To] for all the details.
 
@@ -67,25 +59,22 @@ Great, so how do I create an extension distribution and release it?
 I read that, but it seems like an awful lot of work for something that should be
 automated. Is there any way I can automatically have my extension appear on PGXN
 when I make a release on GitHub?
-
 :   Yes! You can use the [pgxn-tools] Docker image as part of your release
     workflows. It supports both testing an extension with multiple versions of
     Postgres, as well as releasing extensions on GitHub and PGXN. For details,
     check out these blog posts:
 
-:   *   [Test Postgres Extensions With GitHub Actions]
+    *   [Test Postgres Extensions With GitHub Actions]
     *   [Automate Postgres Extension Releases on GitHub and PGXN]
 
 <span id="maillist">
 Is there some place I can go to ask questions and get help from like-minded PGXN
 contributors?
-
 :   Yes, there is a [Google Group] for this very purpose. Join us!
 
 <span id="goodbadugly"></span>
 How does PGXN make it easy to distinguish the garbage from the viable
 extensions?
-
 :   The first step is the PGXN search engine, accessible via the [home page],
     which will allow you to find extensions relevant to you and to read their
     documentation. This will “often ~[be~] enough to distinguish the good stuff
@@ -99,25 +88,36 @@ PGXN Client
 
 <span id="commandlineclient"></span>
 Is there a command-line client for installing extensions from PGXN?
-
 :   There is! Install it with this command:
-:   <pre>sudo easy_install pgxnclient</pre>
-:   Then you can install PGXN extensions with a simple command:
-:   <pre>pgxn install pair</pre>
-:   Run `pgxn help` to get a list of supported commands; or check out the
+
+    ``` sh
+    sudo easy_install pgxnclient
+    ```
+
+    If you use [Homebrew]:
+
+    ``` sh
+    brew install pgxnclient
+    ```
+
+    Then you can install PGXN extensions with a simple command:
+
+    ``` sh
+    pgxn install pair
+    ```
+
+    Run `pgxn help` to get a list of supported commands; or check out the
     introductory [blog][] [posts], the [complete documentation] or the [source
     code].
                    
 <span id="howclientworks"></span>
 How does the command-line client work?
-
 :   It uses JSON-based API available on every PGXN mirror to find, download,
     build, and install extensions. It relies on [PGXS] to do the heavy lifting
     to build extensions.
                    
 <span id="clientwindows"></span>
 What about Windows?
-
 :   The PGXN client follows the lead of the PostgreSQL core on installing
     extensions. If support for installing extensions on Windows improves such
     that a compiler is no longer required, the PGXN client will be modified as
@@ -127,7 +127,6 @@ What about Windows?
                    
 <span id="clientsecurity"></span>
 What kind of security does PGXN have?
-
 :   Each release package has an accompanying SHA1 hash that the PGXN client
     verifies before installing an extension.
 
@@ -136,13 +135,11 @@ Contributing to PGXN
 
 <span id="license"></span>
 Under what license is PGXN’s source code distributed?
-
 :   [The PostgreSQL License]. Note that the actual extensions themselves may be
     under any open source license, determined by their authors.
 
 <span id="contribute"></span>
 Can other people contribute to PGXN?
-
 :   Definitely! Contributions and help with refining the specification are very
     welcome. Major code contributions may be funded out of the PGXN fund based
     on circumstances. Any contributions must be submitted under The PostgreSQL
@@ -150,12 +147,10 @@ Can other people contribute to PGXN?
 
 <span id="mirroring"></span>
 What about mirroring? Can I create a PGXN mirror?
-
 :   Absolutely! See [mirroring] for the details.
                    
 <span id="owners"></span>
 Who owns and runs PGXN?
-
 :   Currently, PGXN is hosted on a box owned by [depesz]. Eventually it may run
     on community servers, as the  PostgreSQL.org Web Team determines. Or it may
     end up on one or more servers to be contributed to the [PostgreSQL Funds
@@ -164,25 +159,21 @@ Who owns and runs PGXN?
                    
 <span id="source"></span>
 Where is the PGXN source code hosted?
-
 :   [On GitHub]. Please feel free to fork and send pull requests!
                    
 <span id="language"></span>
 What language is PGXN written in?
-
 :   Mostly Perl. The database used by [PGXN Manager] is written in SQL,
     PL/pgSQL, and PL/Perl — and even uses [semver], a [semantic version] data
     type written in C and distributed right here on PGXN!
                    
 <span id="api"></span>
 Is there an API?
-
 :   Yes! The [PGXN API] provides centralized index and API of distribution
     metadata, as well as the search APIs used here.
 
 <span id="logos"></span>
 Is the PGXN logo available for use?
-
 :   Yes, see [identity] for the license details and downloadable artwork.
 
   [citext]: https://www.postgresql.org/docs/current/citext.html
@@ -200,15 +191,13 @@ Is the PGXN logo available for use?
   [KISS]: https://en.wikipedia.org/wiki/KISS_principle
   [META.json]: https://pgxn.org/spec/
   [pgxn-tools]: https://github.com/pgxn/docker-pgxn-tools
-  [Test Postgres Extensions With GitHub Actions]:
-    https://justatheory.com/2020/06/test-extensions-with-github-actions/
-  [Automate Postgres Extension Releases on GitHub and PGXN]:
-    https://justatheory.com/2020/10/release-postgres-extensions-with-github-actions/
+  [Test Postgres Extensions With GitHub Actions]: https://justatheory.com/2020/06/test-extensions-with-github-actions/
+  [Automate Postgres Extension Releases on GitHub and PGXN]: https://justatheory.com/2020/10/release-postgres-extensions-with-github-actions/
   [How To]: https://manager.pgxn.org/howto
   [Google Group]: https://groups.google.com/group/pgxn-users
   [home page]: https://pgxn.org/
-  [Robert Haas says]:
-    https://www.postgresql.org/message-id/603c8f071001061718t40e42609y59a26165bb72ff01@mail.gmail.com
+  [Robert Haas says]: https://www.postgresql.org/message-id/603c8f071001061718t40e42609y59a26165bb72ff01@mail.gmail.com
+  [Homebrew]: https://brew.sh
   [blog]: https://blog.pgxn.org/post/5026314153/writing-a-client-for-pgxn
   [posts]: https://blog.pgxn.org/post/5118152273/new-release-for-the-pgxn-client
   [complete documentation]: https://pgxn.github.io/pgxnclient/

--- a/lib/PGXN/Site/Locale/en/feedback.html
+++ b/lib/PGXN/Site/Locale/en/feedback.html
@@ -1,0 +1,22 @@
+<h1 id="feedback">Feedback</h1>
+
+<p>If you have any feedback about this site, its design, or how it presents
+information, then please send an Email to [_1].</p>
+
+<p>If you have a question about an issue with a particular extension, or the
+content of its documentation, please contact the maintainer of that extension.</p>
+
+<p>If the feedback you want to give is not specifically about this site, then
+please try one of the following forums that best fits.</p>
+
+<dl>
+<dt><a href="https://groups.google.com/group/pgxn-users">PGXN Users</a></dt>
+<dd>The PGXN Users group is a great place to go with questions on creating
+PGXN distributions.</dd>
+
+<dt><a href="https://www.postgresql.org/community/lists/">PostgreSQL Mailing Lists</a></dt>
+<dd>The PostgreSQL mailing lists have something for everybody: novices, users,
+and hackers, they’re the place to go for comprehensive discussion of
+everything PostgreSQL.</dd>
+</dl>
+

--- a/lib/PGXN/Site/Locale/en/feedback.mmd
+++ b/lib/PGXN/Site/Locale/en/feedback.mmd
@@ -11,11 +11,10 @@ If the feedback you want to give is not specifically about this site, then
 please try one of the following forums that best fits.
 
 [PGXN Users](https://groups.google.com/group/pgxn-users)
-
-:   The PGXN Users group is a great place to go with questions on creating PGXN distributions.
+:   The PGXN Users group is a great place to go with questions on creating
+    PGXN distributions.
 
 [PostgreSQL Mailing Lists](https://www.postgresql.org/community/lists/)
-
 :   The PostgreSQL mailing lists have something for everybody: novices, users,
     and hackers, they’re the place to go for comprehensive discussion of
     everything PostgreSQL.

--- a/lib/PGXN/Site/Locale/en/mirroring.html
+++ b/lib/PGXN/Site/Locale/en/mirroring.html
@@ -1,0 +1,63 @@
+<h1 id="mirroringpgxn">Mirroring PGXN</h1>
+
+<p>Hosting a PGXN mirror is simple. All you need is:</p>
+
+<ul>
+<li>A reasonably fast internet connection</li>
+<li>Space for storage</li>
+<li>An <a href="https://rsync.samba.org">rsync</a> client</li>
+<li>A web server</li>
+</ul>
+
+<p>The <code>rsync</code> address for the PGXN root mirror is <code>rsync://master.pgxn.org/pgxn</code>.</p>
+
+<p>Once you have the <code>rsync</code> client installed on your system and the disk space
+mapped out, add an entry to your crontab like so:</p>
+
+<pre><code class="cron">0 20 * * * /usr/bin/rsync -az --delete rsync://master.pgxn.org/pgxn /usr/local/pgxn
+</code></pre>
+
+<p>On Windows, use AT like so:</p>
+
+<pre><code>AT 20:00 /every:M,T,W,Th,F,S,Su &quot;C:\Program Files\Rsync\rsync -az --delete rsync://master.pgxn.org/pgxn C:\Projects\PGXN&quot;
+</code></pre>
+
+<p>Please do not sync more than once every hour. And realistically you only need to
+sync once or twice a day. Next, set up a web server to serve the mirror. If your
+rsync is already in the subdirectory of a web server root, you should be golden.
+Otherwise you need a static file web server; perhaps the simplest is this <a href="https://docs.python.org/3/library/http.server.html">Python
+one-liner</a> serving on port 8080:</p>
+
+<pre><code class="sh">python -m http.server 8080
+</code></pre>
+
+<p>If you’re using <a href="https://httpd.apache.org">Apache</a>, you can set up a virtual host like so (assuming that
+you’re <code>rsync</code>ing to <code>/usr/local/pgxn</code>):</p>
+
+<pre><code class="apache">&lt;VirtualHost *:80&gt;
+  DocumentRoot /usr/local/pgxn
+  ServerName pgxn.example.org
+  CustomLog /var/log/httpd/access_log combined
+  &lt;Directory /usr/local/pgxn&gt;
+    AllowOverride All
+    Allow from all
+    Options +Indexes
+  &lt;/Directory&gt;
+&lt;/VirtualHost&gt;
+</code></pre>
+
+<p>For <a href="https://nginx.org">Nginx</a>, you set set up a virtual host like this:</p>
+
+<pre><code class="nginx">server {
+    listen       80;
+    server_name  pgxn.example.org;
+    charset      utf-8;
+    location / {
+        root   /var/local/pgxn;
+        index  index.html;
+    }
+}
+</code></pre>
+
+<p>If you’d like to register your mirror, <a href="mailto:[_1]">send us email</a> with all the details and
+we’ll get you registered.</p>

--- a/lib/PGXN/Site/Locale/en/mirroring.mmd
+++ b/lib/PGXN/Site/Locale/en/mirroring.mmd
@@ -13,11 +13,15 @@ The `rsync` address for the PGXN root mirror is `rsync://master.pgxn.org/pgxn`.
 Once you have the `rsync` client installed on your system and the disk space
 mapped out, add an entry to your crontab like so:
 
-    0 20 * * * /usr/bin/rsync -az --delete rsync://master.pgxn.org/pgxn /usr/local/pgxn
+``` cron
+0 20 * * * /usr/bin/rsync -az --delete rsync://master.pgxn.org/pgxn /usr/local/pgxn
+```
 
 On Windows, use AT like so:
 
-    AT 20:00 /every:M,T,W,Th,F,S,Su "C:\Program Files\Rsync\rsync -az --delete rsync://master.pgxn.org/pgxn C:\Projects\PGXN"
+```
+AT 20:00 /every:M,T,W,Th,F,S,Su "C:\Program Files\Rsync\rsync -az --delete rsync://master.pgxn.org/pgxn C:\Projects\PGXN"
+```
 
 Please do not sync more than once every hour. And realistically you only need to
 sync once or twice a day. Next, set up a web server to serve the mirror. If your
@@ -25,33 +29,39 @@ rsync is already in the subdirectory of a web server root, you should be golden.
 Otherwise you need a static file web server; perhaps the simplest is this [Python
 one-liner] serving on port 8080:
 
-    python -m http.server 8080
+``` sh
+python -m http.server 8080
+```
 
 If you’re using [Apache], you can set up a virtual host like so (assuming that
 you’re `rsync`ing to `/usr/local/pgxn`):
 
-    <VirtualHost *:80>
-      DocumentRoot /usr/local/pgxn
-      ServerName pgxn.example.org
-      CustomLog /var/log/httpd/access_log combined
-      <Directory /usr/local/pgxn>
-        AllowOverride All
-        Allow from all
-        Options +Indexes
-      </Directory>
-    </VirtualHost>
+``` apache
+<VirtualHost *:80>
+  DocumentRoot /usr/local/pgxn
+  ServerName pgxn.example.org
+  CustomLog /var/log/httpd/access_log combined
+  <Directory /usr/local/pgxn>
+    AllowOverride All
+    Allow from all
+    Options +Indexes
+  </Directory>
+</VirtualHost>
+```
 
 For [Nginx], you set set up a virtual host like this:
 
-    server {
-        listen       80;
-        server_name  pgxn.example.org;
-        charset      utf-8;
-        location / {
-            root   /var/local/pgxn;
-            index  index.html;
-        }
+``` nginx
+server {
+    listen       80;
+    server_name  pgxn.example.org;
+    charset      utf-8;
+    location / {
+        root   /var/local/pgxn;
+        index  index.html;
     }
+}
+```
 
 If you’d like to register your mirror, [send us email] with all the details and
 we’ll get you registered.

--- a/lib/PGXN/Site/ui/css/layout.css
+++ b/lib/PGXN/Site/ui/css/layout.css
@@ -123,7 +123,7 @@ b {
 
 ol, ul {
   margin: 10px 0 0 0;
-  padding: 0 0 0 38px;
+  padding: 0 0 10px 38px;
 }
 
 ol span {
@@ -175,11 +175,11 @@ dt {
 
 dd {
   margin-left: 0;
-  padding-left: 15px;
+  padding: 10px 0 15px 15px;
 }
 
 .meta dd {
-  padding-left: 45px;
+  padding: 0 0 0 45px;
 }
 
 dd pre {

--- a/t/router.t
+++ b/t/router.t
@@ -409,7 +409,7 @@ test_psgi $app => sub {
     for my $uri ('/feedback', '/feedback/') {
         ok my $res = $cb->(GET $uri), "Fetch $uri";
         is $res->code, 200, 'Should get 200 response';
-        like $res->content, qr{\Q<h1>Feedback</h1>}, 'The body should look correct';
+        like $res->content, qr{\Q<h1 id="feedback">Feedback</h1>}, 'The body should look correct';
     }
 };
 
@@ -419,7 +419,7 @@ test_psgi $app => sub {
     for my $uri ('/about', '/about/') {
         ok my $res = $cb->(GET $uri), "Fetch $uri";
         is $res->code, 200, 'Should get 200 response';
-        like $res->content, qr{\Q<h1>About PGXN</h1>}, 'The body should look correct';
+        like $res->content, qr{\Q<h1 id="aboutpgxn">About PGXN</h1>}, 'The body should look correct';
     }
 };
 
@@ -439,7 +439,7 @@ test_psgi $app => sub {
     for my $uri ('/faq', '/faq/') {
         ok my $res = $cb->(GET $uri), "Fetch $uri";
         is $res->code, 200, 'Should get 200 response';
-        like $res->content, qr{\Q<h1>Frequently Asked Questions</h1>},
+        like $res->content, qr{\Q<h1 id="frequentlyaskedquestions">Frequently Asked Questions</h1>},
             'The body should look correct';
     }
 };
@@ -450,7 +450,7 @@ test_psgi $app => sub {
     for my $uri ('/mirroring', '/mirroring/') {
         ok my $res = $cb->(GET $uri), "Fetch $uri";
         is $res->code, 200, 'Should get 200 response';
-        like $res->content, qr{\Q<h1>Mirroring PGXN</h1>},
+        like $res->content, qr{\Q<h1 id="mirroringpgxn">Mirroring PGXN</h1>},
             'The body should look correct';
     }
 };


### PR DESCRIPTION
Instead of shipping the .mmd files, ship .html files generated by the `multimarkdown` CLI. Requires a bit of tweaking of the markdown files, but allows the use of fenced code blocks and eliminates a build-time dependency.

Also tweak the CSS to open up some space in definition lists, though not in the meta section of a distribution page. Looks nicer, and should be easier to read.